### PR TITLE
Add cross-platform MAUI client shell

### DIFF
--- a/MetaMorpheus/MetaMorpheus.Maui/App.xaml
+++ b/MetaMorpheus/MetaMorpheus.Maui/App.xaml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Application xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MetaMorpheus.Maui.App">
+    <Application.Resources>
+        <ResourceDictionary>
+            <Color x:Key="PrimaryColor">#512BD4</Color>
+            <Color x:Key="SecondaryColor">#2B0B98</Color>
+            <Style TargetType="Button">
+                <Setter Property="BackgroundColor" Value="{StaticResource PrimaryColor}" />
+                <Setter Property="TextColor" Value="White" />
+                <Setter Property="CornerRadius" Value="8" />
+                <Setter Property="Padding" Value="12,6" />
+            </Style>
+            <Style TargetType="Label">
+                <Setter Property="TextColor" Value="#1F2933" />
+            </Style>
+            <Style TargetType="Entry">
+                <Setter Property="TextColor" Value="#1F2933" />
+                <Setter Property="BackgroundColor" Value="White" />
+            </Style>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/MetaMorpheus/MetaMorpheus.Maui/App.xaml.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/App.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls;
+
+namespace MetaMorpheus.Maui;
+
+public partial class App : Application
+{
+    public App(IServiceProvider serviceProvider)
+    {
+        InitializeComponent();
+        MainPage = serviceProvider.GetRequiredService<MainPage>();
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Commands/AsyncCommand.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Commands/AsyncCommand.cs
@@ -1,0 +1,71 @@
+using System.Windows.Input;
+using Microsoft.Maui.ApplicationModel;
+
+namespace MetaMorpheus.Maui.Commands;
+
+public class AsyncCommand : ICommand
+{
+    private readonly Func<object?, Task> _execute;
+    private readonly Predicate<object?>? _canExecute;
+    private bool _isExecuting;
+
+    public AsyncCommand(Func<Task> execute, Func<bool>? canExecute = null)
+        : this(_ => execute(), canExecute is null ? null : new Predicate<object?>(_ => canExecute()))
+    {
+    }
+
+    public AsyncCommand(Func<object?, Task> execute, Predicate<object?>? canExecute = null)
+    {
+        _execute = execute ?? throw new ArgumentNullException(nameof(execute));
+        _canExecute = canExecute;
+    }
+
+    public event EventHandler? CanExecuteChanged;
+
+    public bool CanExecute(object? parameter)
+    {
+        if (_isExecuting)
+        {
+            return false;
+        }
+
+        return _canExecute?.Invoke(parameter) ?? true;
+    }
+
+    public async void Execute(object? parameter)
+    {
+        if (!CanExecute(parameter))
+        {
+            return;
+        }
+
+        try
+        {
+            _isExecuting = true;
+            RaiseCanExecuteChanged();
+            await _execute(parameter).ConfigureAwait(false);
+        }
+        finally
+        {
+            _isExecuting = false;
+            RaiseCanExecuteChanged();
+        }
+    }
+
+    public void RaiseCanExecuteChanged()
+    {
+        if (CanExecuteChanged is null)
+        {
+            return;
+        }
+
+        if (MainThread.IsMainThread)
+        {
+            CanExecuteChanged.Invoke(this, EventArgs.Empty);
+        }
+        else
+        {
+            MainThread.BeginInvokeOnMainThread(() => CanExecuteChanged?.Invoke(this, EventArgs.Empty));
+        }
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/MainPage.xaml
+++ b/MetaMorpheus/MetaMorpheus.Maui/MainPage.xaml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="MetaMorpheus.Maui.MainPage"
+             Title="MetaMorpheus">
+    <ScrollView>
+        <VerticalStackLayout Padding="24" Spacing="18">
+            <VerticalStackLayout Spacing="4" HorizontalOptions="Center">
+                <Label Text="{Binding Title}" FontAttributes="Bold" FontSize="24" HorizontalOptions="Center" />
+                <Label Text="{Binding Subtitle}" FontSize="14" TextColor="#4B5563" HorizontalOptions="Center" />
+            </VerticalStackLayout>
+
+            <Frame BorderColor="#E5E7EB" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="Spectra files" FontAttributes="Bold" />
+                    <Button Text="Add spectra files"
+                            Command="{Binding AddSpectraCommand}" />
+                    <CollectionView ItemsSource="{Binding SpectraFiles}" HeightRequest="140">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="* , Auto" Padding="4,0">
+                                    <Label Text="{Binding}" VerticalOptions="Center" />
+                                    <Button Text="Remove"
+                                            Margin="12,0,0,0"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveSpectraCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame BorderColor="#E5E7EB" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="Protein databases" FontAttributes="Bold" />
+                    <Button Text="Add protein databases"
+                            Command="{Binding AddProteinDatabaseCommand}" />
+                    <CollectionView ItemsSource="{Binding ProteinDatabases}" HeightRequest="140">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="* , Auto" Padding="4,0">
+                                    <Label VerticalOptions="Center">
+                                        <Label.FormattedText>
+                                            <FormattedString>
+                                                <Span Text="{Binding Path}" />
+                                                <Span Text="{Binding DisplayAnnotation}" FontAttributes="Italic" TextColor="#9CA3AF" />
+                                            </FormattedString>
+                                        </Label.FormattedText>
+                                    </Label>
+                                    <Button Text="Remove"
+                                            Margin="12,0,0,0"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveProteinDatabaseCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame BorderColor="#E5E7EB" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="Tasks" FontAttributes="Bold" />
+                    <Button Text="Add task (.toml)"
+                            Command="{Binding AddTaskCommand}" />
+                    <CollectionView ItemsSource="{Binding Tasks}" HeightRequest="160">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid ColumnDefinitions="* , Auto" Padding="4,0">
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="{Binding DisplayName}" FontAttributes="Bold" />
+                                        <Label Text="{Binding SourcePath}" FontSize="12" TextColor="#6B7280" />
+                                    </VerticalStackLayout>
+                                    <Button Text="Remove"
+                                            Margin="12,0,0,0"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.RemoveTaskCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
+
+            <Frame BorderColor="#E5E7EB" CornerRadius="12" Padding="16">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Output folder" FontAttributes="Bold" />
+                    <Entry Text="{Binding OutputFolder}" />
+                    <Label Text="{Binding OutputFolderDescription}" FontSize="12" TextColor="#6B7280" />
+                </VerticalStackLayout>
+            </Frame>
+
+            <Grid ColumnDefinitions="*,Auto" ColumnSpacing="12" VerticalOptions="Center">
+                <Button Text="Run analysis"
+                        Grid.Column="0"
+                        Command="{Binding RunCommand}" />
+                <Button Text="Clear log"
+                        Grid.Column="1"
+                        Command="{Binding ClearLogCommand}" />
+            </Grid>
+
+            <ProgressBar Progress="{Binding Progress}" HeightRequest="10" />
+            <Label Text="{Binding StatusMessage}" FontAttributes="Italic" />
+
+            <Frame BorderColor="#E5E7EB" CornerRadius="12" Padding="12">
+                <VerticalStackLayout Spacing="8">
+                    <Label Text="Log" FontAttributes="Bold" />
+                    <CollectionView ItemsSource="{Binding LogEntries}" HeightRequest="200">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate>
+                                <Label Text="{Binding .}" FontSize="12" />
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </VerticalStackLayout>
+            </Frame>
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/MetaMorpheus/MetaMorpheus.Maui/MainPage.xaml.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/MainPage.xaml.cs
@@ -1,0 +1,13 @@
+using Microsoft.Maui.Controls;
+using MetaMorpheus.Maui.ViewModels;
+
+namespace MetaMorpheus.Maui;
+
+public partial class MainPage : ContentPage
+{
+    public MainPage(MainViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/MauiProgram.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/MauiProgram.cs
@@ -1,0 +1,22 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Maui.Controls.Hosting;
+using Microsoft.Maui.Hosting;
+
+namespace MetaMorpheus.Maui;
+
+public static class MauiProgram
+{
+    public static MauiApp CreateMauiApp()
+    {
+        var builder = MauiApp.CreateBuilder();
+        builder
+            .UseMauiApp<App>();
+
+        builder.Services.AddSingleton<MainPage>();
+        builder.Services.AddSingleton<MainViewModel>();
+        builder.Services.AddSingleton<TaskOrchestrator>();
+        builder.Services.AddSingleton<IFilePickerService, MauiFilePickerService>();
+
+        return builder.Build();
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/MetaMorpheus.Maui.csproj
+++ b/MetaMorpheus/MetaMorpheus.Maui/MetaMorpheus.Maui.csproj
@@ -1,0 +1,40 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-windows10.0.19041.0;net8.0-maccatalyst</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>MetaMorpheus.Maui</RootNamespace>
+    <UseMaui>true</UseMaui>
+    <SingleProject>true</SingleProject>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <ApplicationTitle>MetaMorpheus</ApplicationTitle>
+    <ApplicationId>com.metamorpheus.maui</ApplicationId>
+    <ApplicationIdGuid>d14355b6-6334-4ce0-8819-2f71b24249f6</ApplicationIdGuid>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-windows10.0.19041.0'">
+    <SupportedOSPlatformVersion>10.0.19041.0</SupportedOSPlatformVersion>
+    <TargetPlatformMinVersion>10.0.19041.0</TargetPlatformMinVersion>
+    <UseWinUI>true</UseWinUI>
+    <EnablePreviewMsixTooling>true</EnablePreviewMsixTooling>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)'=='net8.0-maccatalyst'">
+    <SupportedOSPlatformVersion>13.1</SupportedOSPlatformVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\EngineLayer\EngineLayer.csproj" />
+    <ProjectReference Include="..\TaskLayer\TaskLayer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nett" Version="0.15.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <MauiIcon Include="Resources\AppIcon\appicon.svg" />
+    <MauiSplashScreen Include="Resources\Splash\splash.svg" />
+    <MauiImage Include="Resources\Images\**\*" />
+  </ItemGroup>
+</Project>

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/AppDelegate.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/AppDelegate.cs
@@ -1,0 +1,10 @@
+using Foundation;
+using Microsoft.Maui;
+
+namespace MetaMorpheus.Maui;
+
+[Register("AppDelegate")]
+public class AppDelegate : MauiUIApplicationDelegate
+{
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Entitlements.plist
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Entitlements.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict/>
+</plist>

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Info.plist
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>CFBundleDisplayName</key>
+    <string>MetaMorpheus</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.metamorpheus.maui</string>
+    <key>CFBundleName</key>
+    <string>MetaMorpheus</string>
+    <key>CFBundleVersion</key>
+    <string>1.0</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.developer-tools</string>
+    <key>NSHumanReadableName</key>
+    <string>MetaMorpheus</string>
+  </dict>
+</plist>

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Program.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/MacCatalyst/Program.cs
@@ -1,0 +1,12 @@
+using ObjCRuntime;
+using UIKit;
+
+namespace MetaMorpheus.Maui;
+
+public class Program
+{
+    static void Main(string[] args)
+    {
+        UIApplication.Main(args, null, typeof(AppDelegate));
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/App.xaml
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/App.xaml
@@ -1,0 +1,6 @@
+<maui:MauiWinUIApplication
+    x:Class="MetaMorpheus.Maui.WinUI.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:maui="using:Microsoft.Maui">
+</maui:MauiWinUIApplication>

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/App.xaml.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/App.xaml.cs
@@ -1,0 +1,15 @@
+using Microsoft.Maui;
+using Microsoft.Maui.Hosting;
+using Microsoft.UI.Xaml;
+
+namespace MetaMorpheus.Maui.WinUI;
+
+public partial class App : MauiWinUIApplication
+{
+    public App()
+    {
+        InitializeComponent();
+    }
+
+    protected override MauiApp CreateMauiApp() => MauiProgram.CreateMauiApp();
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/Package.appxmanifest
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/Package.appxmanifest
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Package
+  xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
+  xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities">
+  <Identity Name="com.metamorpheus.maui"
+            Publisher="CN=MetaMorpheus"
+            Version="1.0.0.0" />
+  <Properties>
+    <DisplayName>MetaMorpheus</DisplayName>
+    <PublisherDisplayName>MetaMorpheus</PublisherDisplayName>
+    <Logo>Assets\StoreLogo.png</Logo>
+  </Properties>
+  <Dependencies>
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.19041.0" MaxVersionTested="10.0.19041.0" />
+  </Dependencies>
+  <Resources>
+    <Resource Language="en-us" />
+  </Resources>
+  <Applications>
+    <Application Id="App"
+                 Executable="$targetnametoken$.exe"
+                 EntryPoint="MetaMorpheus.Maui.WinUI.App">
+      <uap:VisualElements DisplayName="MetaMorpheus"
+                          Description="MetaMorpheus cross-platform GUI"
+                          BackgroundColor="transparent"
+                          Square150x150Logo="Assets\Square150x150Logo.png"
+                          Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile Wide310x150Logo="Assets\Wide310x150Logo.png" />
+        <uap:SplashScreen Image="Assets\SplashScreen.png" />
+      </uap:VisualElements>
+    </Application>
+  </Applications>
+  <Capabilities>
+    <rescap:Capability Name="runFullTrust" />
+  </Capabilities>
+</Package>

--- a/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/app.manifest
+++ b/MetaMorpheus/MetaMorpheus.Maui/Platforms/Windows/app.manifest
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="MetaMorpheus.Maui.WinUI.App" />
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware>true/pm</dpiAware>
+      <dpiAwareness>permonitorv2,permonitor</dpiAwareness>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/MetaMorpheus/MetaMorpheus.Maui/Resources/AppIcon/appicon.svg
+++ b/MetaMorpheus/MetaMorpheus.Maui/Resources/AppIcon/appicon.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#512BD4" />
+      <stop offset="100%" stop-color="#2B0B98" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="96" fill="url(#grad)" />
+  <path d="M256 120c-75 0-136 61-136 136s61 136 136 136 136-61 136-136S331 120 256 120zm0 40c53 0 96 43 96 96s-43 96-96 96-96-43-96-96 43-96 96-96z" fill="#FFFFFF" opacity="0.85" />
+  <path d="M208 256h96v32h-96z" fill="#FFFFFF" />
+</svg>

--- a/MetaMorpheus/MetaMorpheus.Maui/Resources/Splash/splash.svg
+++ b/MetaMorpheus/MetaMorpheus.Maui/Resources/Splash/splash.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512">
+  <defs>
+    <linearGradient id="splash" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#6D28D9" />
+      <stop offset="100%" stop-color="#1E1B4B" />
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" fill="url(#splash)" />
+  <path d="M160 320c64-32 128-32 192 0l-24 40c-48-24-96-24-144 0z" fill="#F5F3FF" opacity="0.75" />
+  <circle cx="256" cy="220" r="72" fill="#E0E7FF" opacity="0.85" />
+  <circle cx="256" cy="220" r="36" fill="#FFFFFF" />
+</svg>

--- a/MetaMorpheus/MetaMorpheus.Maui/Services/IFilePickerService.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Services/IFilePickerService.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace MetaMorpheus.Maui.Services;
+
+public interface IFilePickerService
+{
+    Task<IEnumerable<string>> PickSpectraAsync();
+    Task<IEnumerable<string>> PickProteinDatabasesAsync();
+    Task<string?> PickTaskConfigurationAsync();
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Services/MauiFilePickerService.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Services/MauiFilePickerService.cs
@@ -1,0 +1,105 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Devices;
+using Microsoft.Maui.Storage;
+
+namespace MetaMorpheus.Maui.Services;
+
+public class MauiFilePickerService : IFilePickerService
+{
+    private static readonly FilePickerFileType TaskConfigurationFileType = new(new Dictionary<DevicePlatform, IEnumerable<string>>
+    {
+        { DevicePlatform.WinUI, new[] { ".toml" } },
+        { DevicePlatform.macOS, new[] { ".toml" } },
+        { DevicePlatform.iOS, new[] { ".toml" } },
+        { DevicePlatform.Android, new[] { ".toml" } }
+    });
+
+    public async Task<IEnumerable<string>> PickSpectraAsync()
+    {
+        try
+        {
+            var results = await FilePicker.Default.PickMultipleAsync(new PickOptions
+            {
+                PickerTitle = "Select spectra files"
+            }).ConfigureAwait(false);
+
+            if (results == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var resolved = await Task.WhenAll(results.Select(ResolveFileAsync)).ConfigureAwait(false);
+            return resolved.Where(path => !string.IsNullOrWhiteSpace(path))!;
+        }
+        catch
+        {
+            return Enumerable.Empty<string>();
+        }
+    }
+
+    public async Task<IEnumerable<string>> PickProteinDatabasesAsync()
+    {
+        try
+        {
+            var results = await FilePicker.Default.PickMultipleAsync(new PickOptions
+            {
+                PickerTitle = "Select protein databases"
+            }).ConfigureAwait(false);
+
+            if (results == null)
+            {
+                return Enumerable.Empty<string>();
+            }
+
+            var resolved = await Task.WhenAll(results.Select(ResolveFileAsync)).ConfigureAwait(false);
+            return resolved.Where(path => !string.IsNullOrWhiteSpace(path))!;
+        }
+        catch
+        {
+            return Enumerable.Empty<string>();
+        }
+    }
+
+    public async Task<string?> PickTaskConfigurationAsync()
+    {
+        try
+        {
+            var result = await FilePicker.Default.PickAsync(new PickOptions
+            {
+                PickerTitle = "Select a MetaMorpheus task configuration",
+                FileTypes = TaskConfigurationFileType
+            }).ConfigureAwait(false);
+
+            return result == null ? null : await ResolveFileAsync(result).ConfigureAwait(false);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    private static async Task<string?> ResolveFileAsync(FileResult file)
+    {
+        if (!string.IsNullOrWhiteSpace(file.FullPath))
+        {
+            return file.FullPath;
+        }
+
+        try
+        {
+            var target = Path.Combine(FileSystem.CacheDirectory, file.FileName);
+            await using var destination = File.OpenWrite(target);
+            await using var source = await file.OpenReadAsync();
+            await source.CopyToAsync(destination).ConfigureAwait(false);
+            return target;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/Services/TaskOrchestrator.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/Services/TaskOrchestrator.cs
@@ -1,0 +1,212 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using EngineLayer;
+using TaskLayer;
+
+namespace MetaMorpheus.Maui.Services;
+
+public record TaskRunRequest(string Name, MetaMorpheusTask Task);
+
+public class TaskOrchestrator
+{
+    private readonly SemaphoreSlim _runLock = new(1, 1);
+    private bool _isRunning;
+    private string? _lastOutputFolder;
+
+    public TaskOrchestrator()
+    {
+        try
+        {
+            GlobalVariables.SetUpGlobalVariables();
+        }
+        catch
+        {
+            // The view-model will surface initialization failures through log messages.
+        }
+    }
+
+    public event EventHandler? RunStarted;
+
+    public event EventHandler<string?>? RunCompleted;
+
+    public event EventHandler<string>? LogReceived;
+
+    public event EventHandler<string>? StatusUpdated;
+
+    public event EventHandler<double>? ProgressUpdated;
+
+    public async Task RunAsync(IReadOnlyList<TaskRunRequest> tasks, IReadOnlyList<string> spectraFiles, IReadOnlyList<DbForTask> proteinDatabases, string outputFolder, CancellationToken cancellationToken = default)
+    {
+        if (tasks == null)
+        {
+            throw new ArgumentNullException(nameof(tasks));
+        }
+
+        if (spectraFiles == null)
+        {
+            throw new ArgumentNullException(nameof(spectraFiles));
+        }
+
+        if (proteinDatabases == null)
+        {
+            throw new ArgumentNullException(nameof(proteinDatabases));
+        }
+
+        if (string.IsNullOrWhiteSpace(outputFolder))
+        {
+            throw new ArgumentException("Output folder must be provided.", nameof(outputFolder));
+        }
+
+        if (tasks.Count == 0)
+        {
+            throw new InvalidOperationException("At least one MetaMorpheus task must be provided.");
+        }
+
+        if (spectraFiles.Count == 0)
+        {
+            throw new InvalidOperationException("At least one spectra file must be provided.");
+        }
+
+        await _runLock.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            if (_isRunning)
+            {
+                throw new InvalidOperationException("A MetaMorpheus run is already in progress.");
+            }
+
+            _isRunning = true;
+            _lastOutputFolder = null;
+            OnProgressUpdated(0);
+            OnRunStarted();
+            OnLog($"Launching {tasks.Count} task(s) with {spectraFiles.Count} spectra file(s).");
+
+            SubscribeHandlers();
+
+            try
+            {
+                var runner = new EverythingRunnerEngine(tasks.Select(t => (t.Name, t.Task)).ToList(), spectraFiles.ToList(), proteinDatabases.ToList(), outputFolder);
+                await Task.Run(() => runner.Run(), cancellationToken).ConfigureAwait(false);
+            }
+            finally
+            {
+                UnsubscribeHandlers();
+                _isRunning = false;
+                OnRunCompleted(_lastOutputFolder ?? outputFolder);
+            }
+        }
+        finally
+        {
+            _runLock.Release();
+        }
+    }
+
+    private void SubscribeHandlers()
+    {
+        EverythingRunnerEngine.StartingAllTasksEngineHandler += OnStartingAllTasks;
+        EverythingRunnerEngine.FinishedAllTasksEngineHandler += OnFinishedAllTasks;
+        EverythingRunnerEngine.WarnHandler += OnWarn;
+        EverythingRunnerEngine.FinishedWritingAllResultsFileHandler += OnFinishedWritingAllResults;
+
+        MetaMorpheusTask.WarnHandler += OnWarn;
+        MetaMorpheusTask.LogHandler += OnLog;
+        MetaMorpheusTask.OutLabelStatusHandler += OnStatus;
+        MetaMorpheusTask.OutProgressHandler += OnProgress;
+        MetaMorpheusTask.StartingSingleTaskHander += OnStartingTask;
+        MetaMorpheusTask.FinishedSingleTaskHandler += OnFinishedTask;
+        MetaMorpheusTask.FinishedWritingFileHandler += OnFinishedWritingFile;
+
+        MetaMorpheusEngine.WarnHandler += OnWarn;
+        MetaMorpheusEngine.OutLabelStatusHandler += OnStatus;
+        MetaMorpheusEngine.OutProgressHandler += OnProgress;
+    }
+
+    private void UnsubscribeHandlers()
+    {
+        EverythingRunnerEngine.StartingAllTasksEngineHandler -= OnStartingAllTasks;
+        EverythingRunnerEngine.FinishedAllTasksEngineHandler -= OnFinishedAllTasks;
+        EverythingRunnerEngine.WarnHandler -= OnWarn;
+        EverythingRunnerEngine.FinishedWritingAllResultsFileHandler -= OnFinishedWritingAllResults;
+
+        MetaMorpheusTask.WarnHandler -= OnWarn;
+        MetaMorpheusTask.LogHandler -= OnLog;
+        MetaMorpheusTask.OutLabelStatusHandler -= OnStatus;
+        MetaMorpheusTask.OutProgressHandler -= OnProgress;
+        MetaMorpheusTask.StartingSingleTaskHander -= OnStartingTask;
+        MetaMorpheusTask.FinishedSingleTaskHandler -= OnFinishedTask;
+        MetaMorpheusTask.FinishedWritingFileHandler -= OnFinishedWritingFile;
+
+        MetaMorpheusEngine.WarnHandler -= OnWarn;
+        MetaMorpheusEngine.OutLabelStatusHandler -= OnStatus;
+        MetaMorpheusEngine.OutProgressHandler -= OnProgress;
+    }
+
+    private void OnStartingAllTasks(object? sender, EventArgs e) => OnStatus("Preparing tasks...");
+
+    private void OnFinishedAllTasks(object? sender, StringEventArgs e)
+    {
+        _lastOutputFolder = e.S;
+        OnStatus("Finished running MetaMorpheus tasks.");
+    }
+
+    private void OnFinishedWritingAllResults(object? sender, StringEventArgs e)
+    {
+        OnLog($"All task results written to {e.S}");
+    }
+
+    private void OnWarn(object? sender, StringEventArgs e) => OnLog($"⚠️ {e.S}");
+
+    private void OnLog(object? sender, StringEventArgs e) => OnLog(e.S);
+
+    private void OnLog(string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            LogReceived?.Invoke(this, message);
+        }
+    }
+
+    private void OnStatus(object? sender, StringEventArgs e) => OnStatus(e.S);
+
+    private void OnProgress(object? sender, ProgressEventArgs e)
+    {
+        var normalized = Math.Clamp(e.NewProgress / 100d, 0d, 1d);
+        OnProgressUpdated(normalized);
+        if (!string.IsNullOrWhiteSpace(e.V))
+        {
+            OnStatus(e.V);
+        }
+    }
+
+    private void OnFinishedWritingFile(object? sender, SingleFileEventArgs e)
+    {
+        OnLog($"Finished writing file: {e.WrittenFile}");
+    }
+
+    private void OnStartingTask(object? sender, SingleTaskEventArgs e)
+    {
+        OnLog($"Starting task: {e.DisplayName}");
+    }
+
+    private void OnFinishedTask(object? sender, SingleTaskEventArgs e)
+    {
+        OnLog($"Finished task: {e.DisplayName}");
+    }
+
+    private void OnRunStarted() => RunStarted?.Invoke(this, EventArgs.Empty);
+
+    private void OnRunCompleted(string? outputFolder) => RunCompleted?.Invoke(this, outputFolder);
+
+    private void OnStatus(string? message)
+    {
+        if (!string.IsNullOrWhiteSpace(message))
+        {
+            StatusUpdated?.Invoke(this, message);
+        }
+    }
+
+    private void OnProgressUpdated(double progress) => ProgressUpdated?.Invoke(this, progress);
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/ViewModels/BaseViewModel.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/ViewModels/BaseViewModel.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace MetaMorpheus.Maui.ViewModels;
+
+public abstract class BaseViewModel : INotifyPropertyChanged
+{
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected bool SetProperty<T>(ref T storage, T value, [CallerMemberName] string? propertyName = null)
+    {
+        if (EqualityComparer<T>.Default.Equals(storage, value))
+        {
+            return false;
+        }
+
+        storage = value;
+        OnPropertyChanged(propertyName);
+        return true;
+    }
+
+    protected void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/ViewModels/MainViewModel.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/ViewModels/MainViewModel.cs
@@ -1,0 +1,455 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Storage;
+using MetaMorpheus.Maui.Commands;
+using MetaMorpheus.Maui.Services;
+using Nett;
+using TaskLayer;
+using EngineLayer;
+
+namespace MetaMorpheus.Maui.ViewModels;
+
+public class MainViewModel : BaseViewModel
+{
+    private readonly TaskOrchestrator _taskOrchestrator;
+    private readonly IFilePickerService _filePickerService;
+    private readonly AsyncCommand _addSpectraCommand;
+    private readonly AsyncCommand _addProteinDatabaseCommand;
+    private readonly AsyncCommand _addTaskCommand;
+    private readonly AsyncCommand _runCommand;
+    private readonly Command<string> _removeSpectraCommand;
+    private readonly Command<ProteinDatabaseViewModel> _removeProteinDatabaseCommand;
+    private readonly Command<TaskItemViewModel> _removeTaskCommand;
+    private readonly Command _clearLogCommand;
+
+    private string _title = "MetaMorpheus";
+    private string _subtitle = "Cross-platform preview";
+    private string _outputFolder = string.Empty;
+    private string _outputFolderDescription = string.Empty;
+    private string _statusMessage = string.Empty;
+    private double _progress;
+    private bool _isBusy;
+
+    public MainViewModel(TaskOrchestrator taskOrchestrator, IFilePickerService filePickerService)
+    {
+        _taskOrchestrator = taskOrchestrator;
+        _filePickerService = filePickerService;
+
+        SpectraFiles.CollectionChanged += OnCollectionChanged;
+        ProteinDatabases.CollectionChanged += OnCollectionChanged;
+        Tasks.CollectionChanged += OnCollectionChanged;
+
+        InitializeVersionInformation();
+
+        OutputFolder = GetDefaultOutputFolder();
+        OutputFolderDescription = "Edit the path to choose where MetaMorpheus writes results.";
+
+        _addSpectraCommand = new AsyncCommand(AddSpectraAsync, () => !IsBusy);
+        AddSpectraCommand = _addSpectraCommand;
+
+        _addProteinDatabaseCommand = new AsyncCommand(AddProteinDatabasesAsync, () => !IsBusy);
+        AddProteinDatabaseCommand = _addProteinDatabaseCommand;
+
+        _addTaskCommand = new AsyncCommand(AddTaskAsync, () => !IsBusy);
+        AddTaskCommand = _addTaskCommand;
+
+        _runCommand = new AsyncCommand(RunAsync, () => CanRun);
+        RunCommand = _runCommand;
+
+        _removeSpectraCommand = new Command<string>(RemoveSpectra, _ => !IsBusy);
+        RemoveSpectraCommand = _removeSpectraCommand;
+
+        _removeProteinDatabaseCommand = new Command<ProteinDatabaseViewModel>(RemoveProteinDatabase, _ => !IsBusy);
+        RemoveProteinDatabaseCommand = _removeProteinDatabaseCommand;
+
+        _removeTaskCommand = new Command<TaskItemViewModel>(RemoveTask, _ => !IsBusy);
+        RemoveTaskCommand = _removeTaskCommand;
+
+        _clearLogCommand = new Command(ClearLog);
+        ClearLogCommand = _clearLogCommand;
+
+        _taskOrchestrator.LogReceived += (_, message) => AddLog(message);
+        _taskOrchestrator.StatusUpdated += (_, message) => StatusMessage = message;
+        _taskOrchestrator.ProgressUpdated += (_, value) => Progress = value;
+        _taskOrchestrator.RunStarted += (_, __) => OnRunStarted();
+        _taskOrchestrator.RunCompleted += (_, result) => OnRunCompleted(result);
+    }
+
+    public ObservableCollection<string> SpectraFiles { get; } = new();
+
+    public ObservableCollection<ProteinDatabaseViewModel> ProteinDatabases { get; } = new();
+
+    public ObservableCollection<TaskItemViewModel> Tasks { get; } = new();
+
+    public ObservableCollection<string> LogEntries { get; } = new();
+
+    public ICommand AddSpectraCommand { get; }
+
+    public ICommand AddProteinDatabaseCommand { get; }
+
+    public ICommand AddTaskCommand { get; }
+
+    public ICommand RunCommand { get; }
+
+    public ICommand RemoveSpectraCommand { get; }
+
+    public ICommand RemoveProteinDatabaseCommand { get; }
+
+    public ICommand RemoveTaskCommand { get; }
+
+    public ICommand ClearLogCommand { get; }
+
+    public string Title
+    {
+        get => _title;
+        private set => SetProperty(ref _title, value);
+    }
+
+    public string Subtitle
+    {
+        get => _subtitle;
+        private set => SetProperty(ref _subtitle, value);
+    }
+
+    public string OutputFolder
+    {
+        get => _outputFolder;
+        set
+        {
+            if (SetProperty(ref _outputFolder, value))
+            {
+                EnsureOutputFolderExists(value);
+            }
+        }
+    }
+
+    public string OutputFolderDescription
+    {
+        get => _outputFolderDescription;
+        private set => SetProperty(ref _outputFolderDescription, value);
+    }
+
+    public string StatusMessage
+    {
+        get => _statusMessage;
+        private set => SetProperty(ref _statusMessage, value);
+    }
+
+    public double Progress
+    {
+        get => _progress;
+        private set => SetProperty(ref _progress, value);
+    }
+
+    public bool IsBusy
+    {
+        get => _isBusy;
+        private set
+        {
+            if (SetProperty(ref _isBusy, value))
+            {
+                UpdateCommandStates();
+                OnPropertyChanged(nameof(CanRun));
+            }
+        }
+    }
+
+    public bool CanRun => !IsBusy && Tasks.Any() && SpectraFiles.Any();
+
+    private void InitializeVersionInformation()
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(GlobalVariables.MetaMorpheusVersion))
+            {
+                GlobalVariables.SetUpGlobalVariables();
+            }
+
+            Title = $"MetaMorpheus {GlobalVariables.MetaMorpheusVersion}";
+            Subtitle = "Cross-platform preview build";
+        }
+        catch (Exception ex)
+        {
+            AddLog($"Unable to load MetaMorpheus version: {ex.Message}");
+        }
+    }
+
+    private static string GetDefaultOutputFolder()
+    {
+        var baseFolder = Path.Combine(FileSystem.AppDataDirectory, "MetaMorpheus", "Results");
+        return baseFolder;
+    }
+
+    private void EnsureOutputFolderExists(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        try
+        {
+            Directory.CreateDirectory(path);
+        }
+        catch
+        {
+            AddLog($"Unable to create output directory at {path}.");
+        }
+    }
+
+    private void OnCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(CanRun));
+        _runCommand.RaiseCanExecuteChanged();
+    }
+
+    private async Task AddSpectraAsync()
+    {
+        var files = await _filePickerService.PickSpectraAsync().ConfigureAwait(false);
+        var selections = files?.ToList();
+        if (selections == null || selections.Count == 0)
+        {
+            return;
+        }
+
+        await MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            foreach (var path in selections)
+            {
+                if (!SpectraFiles.Contains(path))
+                {
+                    SpectraFiles.Add(path);
+                }
+            }
+        });
+
+        AddLog($"Added {selections.Count} spectra file(s).");
+    }
+
+    private async Task AddProteinDatabasesAsync()
+    {
+        var files = await _filePickerService.PickProteinDatabasesAsync().ConfigureAwait(false);
+        var selections = files?.ToList();
+        if (selections == null || selections.Count == 0)
+        {
+            return;
+        }
+
+        await MainThread.InvokeOnMainThreadAsync(() =>
+        {
+            foreach (var path in selections)
+            {
+                if (ProteinDatabases.Any(db => db.Path == path))
+                {
+                    continue;
+                }
+
+                ProteinDatabases.Add(new ProteinDatabaseViewModel(path, IsContaminant(path)));
+            }
+        });
+
+        AddLog($"Added {selections.Count} protein database file(s).");
+    }
+
+    private async Task AddTaskAsync()
+    {
+        var taskPath = await _filePickerService.PickTaskConfigurationAsync().ConfigureAwait(false);
+        if (string.IsNullOrWhiteSpace(taskPath))
+        {
+            return;
+        }
+
+        if (Tasks.Any(t => t.SourcePath == taskPath))
+        {
+            AddLog($"Task already loaded: {taskPath}");
+            return;
+        }
+
+        try
+        {
+            var taskItem = await LoadTaskFromFileAsync(taskPath).ConfigureAwait(false);
+            if (taskItem == null)
+            {
+                AddLog($"Unsupported task configuration: {taskPath}");
+                return;
+            }
+
+            await MainThread.InvokeOnMainThreadAsync(() => Tasks.Add(taskItem));
+            AddLog($"Loaded task '{taskItem.DisplayName}'.");
+        }
+        catch (Exception ex)
+        {
+            AddLog($"Failed to read task configuration: {ex.Message}");
+        }
+    }
+
+    private async Task<TaskItemViewModel?> LoadTaskFromFileAsync(string filePath)
+    {
+        return await Task.Run(() =>
+        {
+            var toml = Toml.ReadFile(filePath, MetaMorpheusTask.tomlConfig);
+            var taskType = toml.Get<string>("TaskType");
+
+            MetaMorpheusTask? task = taskType switch
+            {
+                "Search" => Toml.ReadFile<SearchTask>(filePath, MetaMorpheusTask.tomlConfig),
+                "Calibrate" => Toml.ReadFile<CalibrationTask>(filePath, MetaMorpheusTask.tomlConfig),
+                "Gptmd" => Toml.ReadFile<GptmdTask>(filePath, MetaMorpheusTask.tomlConfig),
+                "XLSearch" => Toml.ReadFile<XLSearchTask>(filePath, MetaMorpheusTask.tomlConfig),
+                "GlycoSearch" => Toml.ReadFile<GlycoSearchTask>(filePath, MetaMorpheusTask.tomlConfig),
+                "Average" => Toml.ReadFile<SpectralAveragingTask>(filePath, MetaMorpheusTask.tomlConfig),
+                _ => null
+            };
+
+            if (task == null)
+            {
+                return null;
+            }
+
+            var displayName = Path.GetFileNameWithoutExtension(filePath);
+            return new TaskItemViewModel(displayName, filePath, task);
+        }).ConfigureAwait(false);
+    }
+
+    private async Task RunAsync()
+    {
+        if (IsBusy)
+        {
+            return;
+        }
+
+        if (!SpectraFiles.Any())
+        {
+            AddLog("Select at least one spectra file before running.");
+            return;
+        }
+
+        if (!Tasks.Any())
+        {
+            AddLog("Add at least one MetaMorpheus task before running.");
+            return;
+        }
+
+        var taskDefinitions = Tasks.Select((task, index) =>
+            new TaskRunRequest($"Task{index + 1}_{task.TaskType}", task.Task)).ToList();
+
+        var spectra = SpectraFiles.ToList();
+        var databases = ProteinDatabases.Select(db => db.ToDbForTask()).ToList();
+
+        try
+        {
+            await _taskOrchestrator.RunAsync(taskDefinitions, spectra, databases, OutputFolder).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            AddLog($"Run failed: {ex.Message}");
+            MainThread.BeginInvokeOnMainThread(() =>
+            {
+                IsBusy = false;
+                StatusMessage = "Run failed";
+                Progress = 0;
+            });
+        }
+    }
+
+    private void RemoveSpectra(string? path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+        {
+            return;
+        }
+
+        SpectraFiles.Remove(path);
+    }
+
+    private void RemoveProteinDatabase(ProteinDatabaseViewModel? database)
+    {
+        if (database == null)
+        {
+            return;
+        }
+
+        ProteinDatabases.Remove(database);
+    }
+
+    private void RemoveTask(TaskItemViewModel? task)
+    {
+        if (task == null)
+        {
+            return;
+        }
+
+        Tasks.Remove(task);
+    }
+
+    private void ClearLog()
+    {
+        LogEntries.Clear();
+    }
+
+    private void OnRunStarted()
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            IsBusy = true;
+            StatusMessage = "Running MetaMorpheus tasks...";
+            Progress = 0;
+        });
+    }
+
+    private void OnRunCompleted(string? outputFolder)
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            IsBusy = false;
+            Progress = 1;
+            StatusMessage = string.IsNullOrWhiteSpace(outputFolder)
+                ? "Run complete"
+                : $"Run complete. Results: {outputFolder}";
+        });
+    }
+
+    private void UpdateCommandStates()
+    {
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            _addSpectraCommand.RaiseCanExecuteChanged();
+            _addProteinDatabaseCommand.RaiseCanExecuteChanged();
+            _addTaskCommand.RaiseCanExecuteChanged();
+            _runCommand.RaiseCanExecuteChanged();
+            _removeSpectraCommand.ChangeCanExecute();
+            _removeProteinDatabaseCommand.ChangeCanExecute();
+            _removeTaskCommand.ChangeCanExecute();
+        });
+    }
+
+    private void AddLog(string? message)
+    {
+        if (string.IsNullOrWhiteSpace(message))
+        {
+            return;
+        }
+
+        var entry = $"{DateTime.Now:HH:mm:ss} {message}";
+        MainThread.BeginInvokeOnMainThread(() =>
+        {
+            LogEntries.Add(entry);
+            while (LogEntries.Count > 500)
+            {
+                LogEntries.RemoveAt(0);
+            }
+        });
+    }
+
+    private static bool IsContaminant(string path)
+    {
+        var upper = Path.GetFileName(path).ToUpperInvariant();
+        return upper.Contains("CONTAMINANT") || upper.Contains("CRAP");
+    }
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/ViewModels/ProteinDatabaseViewModel.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/ViewModels/ProteinDatabaseViewModel.cs
@@ -1,0 +1,20 @@
+using TaskLayer;
+
+namespace MetaMorpheus.Maui.ViewModels;
+
+public class ProteinDatabaseViewModel
+{
+    public ProteinDatabaseViewModel(string path, bool isContaminant)
+    {
+        Path = path;
+        IsContaminant = isContaminant;
+    }
+
+    public string Path { get; }
+
+    public bool IsContaminant { get; }
+
+    public string DisplayAnnotation => IsContaminant ? "  (contaminant)" : string.Empty;
+
+    public DbForTask ToDbForTask() => new(Path, IsContaminant);
+}

--- a/MetaMorpheus/MetaMorpheus.Maui/ViewModels/TaskItemViewModel.cs
+++ b/MetaMorpheus/MetaMorpheus.Maui/ViewModels/TaskItemViewModel.cs
@@ -1,0 +1,25 @@
+using System.IO;
+using TaskLayer;
+
+namespace MetaMorpheus.Maui.ViewModels;
+
+public class TaskItemViewModel
+{
+    public TaskItemViewModel(string displayName, string sourcePath, MetaMorpheusTask task)
+    {
+        DisplayName = displayName;
+        SourcePath = sourcePath;
+        Task = task;
+        TaskType = task.TaskType.ToString();
+    }
+
+    public string DisplayName { get; }
+
+    public string SourcePath { get; }
+
+    public string TaskType { get; }
+
+    public MetaMorpheusTask Task { get; }
+
+    public string ShortSourceName => Path.GetFileName(SourcePath);
+}

--- a/MetaMorpheus/MetaMorpheus.sln
+++ b/MetaMorpheus/MetaMorpheus.sln
@@ -22,6 +22,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test", "Test\Test.csproj", 
 EndProject
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "Bootstrapper", "Bootstrapper\Bootstrapper.wixproj", "{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetaMorpheus.Maui", "MetaMorpheus.Maui\MetaMorpheus.Maui.csproj", "{7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -71,10 +73,16 @@ Global
 		{7EE028A9-75A2-450F-A9A7-76559ED15419}.UbuntuMac|Any CPU.Build.0 = Release|Any CPU
 		{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Debug|Any CPU.ActiveCfg = Debug|x64
 		{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Debug|Any CPU.Build.0 = Debug|x64
-		{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Release|Any CPU.ActiveCfg = Release|x64
-		{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Release|Any CPU.Build.0 = Release|x64
-		{E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.UbuntuMac|Any CPU.ActiveCfg = Release|x64
-	EndGlobalSection
+                {E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Release|Any CPU.ActiveCfg = Release|x64
+                {E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.Release|Any CPU.Build.0 = Release|x64
+                {E0EA5AC4-24A9-43DC-8FBC-CCEB3B9935B6}.UbuntuMac|Any CPU.ActiveCfg = Release|x64
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.Release|Any CPU.Build.0 = Release|Any CPU
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.UbuntuMac|Any CPU.ActiveCfg = Release|Any CPU
+                {7A5A5D39-FFC1-46B7-A830-D99CD9040BE1}.UbuntuMac|Any CPU.Build.0 = Release|Any CPU
+        EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection


### PR DESCRIPTION
## Summary
- add a new MetaMorpheus.Maui project that multi-targets Windows and Mac Catalyst
- scaffold MAUI UI, view models, and services that wrap existing MetaMorpheus task orchestration
- update the solution file and include platform-specific manifests and resources for the new client

## Testing
- not run (dotnet CLI is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68cb19b5da0c83239925660f88f116e5