### PR TITLE
Cover the spectral library update path directly

### DIFF
--- a/MetaMorpheus/Test/SpectralLibraryUpdateTests.cs
+++ b/MetaMorpheus/Test/SpectralLibraryUpdateTests.cs
@@ -1,9 +1,21 @@
+using Chemistry;
 using EngineLayer;
+using EngineLayer.DatabaseLoading;
+using MassSpectrometry;
 using NUnit.Framework;
+using Omics.Digestion;
+using Omics.Fragmentation;
+using Omics.Modifications;
+using Omics.SpectrumMatch;
+using Proteomics;
+using Proteomics.ProteolyticDigestion;
+using Readers.SpectralLibrary;
+using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Reflection;
 using TaskLayer;
-using EngineLayer.DatabaseLoading;
 
 namespace Test
 {
@@ -45,5 +57,383 @@ namespace Test
 
             Directory.Delete(outputFolder, recursive: true);
         }
+
+        /// <summary>
+        /// The guard SearchTask now applies is only reachable when a spectral library is actually in the
+        /// database list, so this pins the precondition it reads: LoadSpectralLibraries returns null when
+        /// nothing in the list is a library, and a real library when something is. If that ever changed to
+        /// return an empty SpectralLibrary instead of null, the refusal above would silently stop firing.
+        /// </summary>
+        [Test]
+        public static void LoadSpectralLibrariesReturnsNullOnlyWhenNoLibraryIsInTheDatabaseList()
+        {
+            var task = new SearchTask();
+            var load = typeof(MetaMorpheusTask).GetMethod("LoadSpectralLibraries",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.That(load, Is.Not.Null, "LoadSpectralLibraries is the seam SearchTask's guard depends on");
+
+            var fastaOnly = new List<DbForTask> { new DbForTask(HelaSnipFasta, false) };
+            Assert.That(load.Invoke(task, new object[] { "id", fastaOnly }), Is.Null);
+
+            Assert.That(load.Invoke(task, new object[] { "id", new List<DbForTask>() }), Is.Null,
+                "an empty database list has no library either");
+
+            var withLibrary = new List<DbForTask>
+            {
+                new DbForTask(HelaSnipFasta, false),
+                new DbForTask(SmallLibrary, false)
+            };
+            var loaded = load.Invoke(task, new object[] { "id", withLibrary });
+            Assert.That(loaded, Is.Not.Null);
+            ((SpectralLibrary)loaded).CloseConnections();
+        }
+
+        /// <summary>
+        /// The null guard PR #2721 adds to PostSearchAnalysisTask.UpdateSpectralLibrary. SearchTask refuses
+        /// the combination before searching, so this branch is only reachable by a caller that assembles
+        /// PostSearchAnalysisParameters itself — which is exactly what this test does.
+        ///
+        /// Without the guard the method dereferences the missing library, the surrounding catch turns that
+        /// into an UpdateSpectralLibrary_crash.txt nobody reads, and the task reports success. Asserting the
+        /// crash file is absent is what makes this a regression test rather than a restatement of the code.
+        /// </summary>
+        [Test]
+        public static void UpdateSpectralLibraryWithoutALibraryWarnsAndLeavesNothingBehind()
+        {
+            string outputFolder = MakeOutputFolder("NoLibraryPostSearch");
+
+            var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
+            task.Parameters = new PostSearchAnalysisParameters
+            {
+                SearchParameters = new SearchParameters { UpdateSpectralLibrary = true },
+                OutputFolder = outputFolder,
+                SearchTaskId = "NoLibraryPostSearch",
+                AllSpectralMatches = new List<SpectralMatch>(),
+                DatabaseFilenameList = new List<DbForTask>(),
+                SpectralLibrary = null,
+                SearchTaskResults = NewTaskResults(task)
+            };
+
+            var warnings = CaptureWarnings(() => InvokePrivate(task, "UpdateSpectralLibrary"));
+
+            Assert.That(warnings.Any(w => w.Contains("spectral library", StringComparison.OrdinalIgnoreCase)),
+                Is.True, "the user has to be told why no library came out: " + string.Join(" | ", warnings));
+            Assert.That(File.Exists(Path.Combine(outputFolder, "UpdateSpectralLibrary_crash.txt")), Is.False,
+                "a missing library is a configuration problem, not an engine crash");
+            Assert.That(Directory.GetFiles(outputFolder, "updateSpectralLibrary*.msp"), Is.Empty,
+                "nothing to update means nothing written");
+            Assert.That(task.Parameters.SearchTaskResults.NewDatabases, Is.Null,
+                "no library was produced, so none may be advertised to the next task in the run");
+
+            Directory.Delete(outputFolder, recursive: true);
+        }
+
+        /// <summary>
+        /// The other side of the same guard: given a library and no search results, every original spectrum
+        /// has to survive into the updated library, and the updated library plus the original protein
+        /// database have to be handed to the next task. This is the path the guard exists to protect, and
+        /// until now it was covered only by a full two-file search that takes about seven seconds.
+        /// </summary>
+        [Test]
+        public static void UpdateSpectralLibraryWithNoSearchResultsCarriesEveryOriginalSpectrumThrough()
+        {
+            string outputFolder = MakeOutputFolder("LibraryNoPsms");
+            var library = new SpectralLibrary(new List<string> { SmallLibrary });
+
+            var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
+            task.Parameters = new PostSearchAnalysisParameters
+            {
+                SearchParameters = new SearchParameters { UpdateSpectralLibrary = true },
+                OutputFolder = outputFolder,
+                SearchTaskId = "LibraryNoPsms",
+                AllSpectralMatches = new List<SpectralMatch>(),
+                DatabaseFilenameList = new List<DbForTask>
+                {
+                    new DbForTask(SmallLibrary, false),
+                    new DbForTask(HelaSnipFasta, false)
+                },
+                SpectralLibrary = library,
+                SearchTaskResults = NewTaskResults(task)
+            };
+
+            var originalSequences = library.GetAllLibrarySpectra().Select(s => s.Sequence).OrderBy(s => s).ToList();
+            Assert.That(originalSequences.Count, Is.EqualTo(3), "fixture changed; the assertions below assume three spectra");
+
+            var warnings = CaptureWarnings(() => InvokePrivate(task, "UpdateSpectralLibrary"));
+            library.CloseConnections();
+
+            Assert.That(warnings, Is.Empty, "nothing went wrong: " + string.Join(" | ", warnings));
+
+            var written = Directory.GetFiles(outputFolder, "updateSpectralLibrary*.msp");
+            Assert.That(written.Length, Is.EqualTo(1), "exactly one updated library should be written");
+
+            var updated = new SpectralLibrary(new List<string> { written[0] });
+            var updatedSequences = updated.GetAllLibrarySpectra().Select(s => s.Sequence).OrderBy(s => s).ToList();
+            updated.CloseConnections();
+            Assert.That(updatedSequences, Is.EqualTo(originalSequences),
+                "with no PSMs to compare against, an update must not lose or invent a spectrum");
+
+            var newDatabases = task.Parameters.SearchTaskResults.NewDatabases;
+            Assert.That(newDatabases.Count, Is.EqualTo(2));
+            Assert.That(newDatabases[0].FilePath, Is.EqualTo(written[0]));
+            Assert.That(newDatabases[0].IsSpectralLibrary, Is.True);
+            Assert.That(newDatabases[1].FilePath, Is.EqualTo(HelaSnipFasta),
+                "the protein database has to travel with the library or the next task has nothing to search");
+
+            Directory.Delete(outputFolder, recursive: true);
+        }
+
+        /// <summary>
+        /// The selection rule at the heart of the update: for a peptide/charge already in the library, the
+        /// search result replaces the stored spectrum only when the stored one has fewer matched ions than
+        /// the PSM's score. Both outcomes are exercised here from the same fixture, so a change to the
+        /// comparison shows up as a failure rather than as a quietly different library.
+        /// </summary>
+        [Test]
+        [TestCase(30d, true, TestName = "UpdateSpectralLibraryReplacesTheStoredSpectrumWhenThePsmScoresHigher")]
+        [TestCase(2d, false, TestName = "UpdateSpectralLibraryKeepsTheStoredSpectrumWhenThePsmScoresLower")]
+        public static void UpdateSpectralLibraryPrefersTheBetterOfTheStoredSpectrumAndTheSearchResult(
+            double psmScore, bool expectReplacement)
+        {
+            string outputFolder = MakeOutputFolder("LibraryVsPsm_" + psmScore);
+            var library = new SpectralLibrary(new List<string> { SmallLibrary });
+
+            var stored = library.GetAllLibrarySpectra().Single(s => s.Sequence == RepeatedSequence);
+            Assert.That(stored.ChargeState, Is.EqualTo(2), "fixture changed; the PSM below is built at charge 2");
+
+            var psm = MakePsm(RepeatedSequence, charge: 2, score: psmScore);
+            Assert.That(psm.MatchedFragmentIons.Count, Is.Not.EqualTo(stored.MatchedFragmentIons.Count),
+                "the two spectra must be distinguishable for this test to mean anything");
+
+            var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
+            task.Parameters = new PostSearchAnalysisParameters
+            {
+                SearchParameters = new SearchParameters { UpdateSpectralLibrary = true },
+                OutputFolder = outputFolder,
+                SearchTaskId = "LibraryVsPsm",
+                AllSpectralMatches = new List<SpectralMatch> { psm },
+                DatabaseFilenameList = new List<DbForTask>
+                {
+                    new DbForTask(SmallLibrary, false),
+                    new DbForTask(HelaSnipFasta, false)
+                },
+                SpectralLibrary = library,
+                SearchTaskResults = NewTaskResults(task)
+            };
+
+            InvokePrivate(task, "UpdateSpectralLibrary");
+            library.CloseConnections();
+
+            var written = Directory.GetFiles(outputFolder, "updateSpectralLibrary*.msp").Single();
+            var updated = new SpectralLibrary(new List<string> { written });
+            var all = updated.GetAllLibrarySpectra().ToList();
+            var result = all.Single(s => s.Sequence == RepeatedSequence);
+            int resultIonCount = result.MatchedFragmentIons.Count;
+            updated.CloseConnections();
+
+            Assert.That(all.Count, Is.EqualTo(3),
+                "the peptide was already in the library, so it must be replaced rather than appended");
+            Assert.That(resultIonCount, Is.EqualTo(expectReplacement
+                    ? psm.MatchedFragmentIons.Count
+                    : stored.MatchedFragmentIons.Count),
+                expectReplacement
+                    ? "a PSM scoring above the stored ion count should win"
+                    : "a PSM scoring below the stored ion count should not displace it");
+
+            Directory.Delete(outputFolder, recursive: true);
+        }
+
+        /// <summary>
+        /// A confidently identified peptide that the library has never seen has to be added, not dropped —
+        /// growing the library is the point of asking for an update at all.
+        /// </summary>
+        [Test]
+        public static void UpdateSpectralLibraryAppendsAPeptideTheLibraryHasNotSeen()
+        {
+            string outputFolder = MakeOutputFolder("LibraryNewPeptide");
+            var library = new SpectralLibrary(new List<string> { SmallLibrary });
+
+            const string newSequence = "PEPTIDEK";
+            Assert.That(library.GetAllLibrarySpectra().Any(s => s.Sequence == newSequence), Is.False,
+                "fixture changed; this peptide is supposed to be absent from the library");
+
+            var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
+            task.Parameters = new PostSearchAnalysisParameters
+            {
+                SearchParameters = new SearchParameters { UpdateSpectralLibrary = true },
+                OutputFolder = outputFolder,
+                SearchTaskId = "LibraryNewPeptide",
+                AllSpectralMatches = new List<SpectralMatch> { MakePsm(newSequence, charge: 2, score: 12) },
+                DatabaseFilenameList = new List<DbForTask>
+                {
+                    new DbForTask(SmallLibrary, false),
+                    new DbForTask(HelaSnipFasta, false)
+                },
+                SpectralLibrary = library,
+                SearchTaskResults = NewTaskResults(task)
+            };
+
+            InvokePrivate(task, "UpdateSpectralLibrary");
+            library.CloseConnections();
+
+            var written = Directory.GetFiles(outputFolder, "updateSpectralLibrary*.msp").Single();
+            var updated = new SpectralLibrary(new List<string> { written });
+            var sequences = updated.GetAllLibrarySpectra().Select(s => s.Sequence).ToList();
+            updated.CloseConnections();
+
+            Assert.That(sequences.Count, Is.EqualTo(4), "three originals plus the newly identified peptide");
+            Assert.That(sequences, Does.Contain(newSequence));
+
+            Directory.Delete(outputFolder, recursive: true);
+        }
+
+        /// <summary>
+        /// A decoy or a low-confidence hit must never reach the library — an updated library is used as
+        /// ground truth by the next search, so anything that leaks in is amplified.
+        /// </summary>
+        [Test]
+        public static void UpdateSpectralLibraryIgnoresDecoyAndLowConfidenceMatches()
+        {
+            string outputFolder = MakeOutputFolder("LibraryFiltering");
+            var library = new SpectralLibrary(new List<string> { SmallLibrary });
+
+            var decoy = MakePsm("DECOYPEPTIDEK", charge: 2, score: 40, isDecoy: true);
+            var lowConfidence = MakePsm("BADQVALUEPEPTIDEK", charge: 2, score: 40, qValue: 0.5);
+
+            var task = new PostSearchAnalysisTask { CommonParameters = new CommonParameters() };
+            task.Parameters = new PostSearchAnalysisParameters
+            {
+                SearchParameters = new SearchParameters { UpdateSpectralLibrary = true },
+                OutputFolder = outputFolder,
+                SearchTaskId = "LibraryFiltering",
+                AllSpectralMatches = new List<SpectralMatch> { decoy, lowConfidence },
+                DatabaseFilenameList = new List<DbForTask>
+                {
+                    new DbForTask(SmallLibrary, false),
+                    new DbForTask(HelaSnipFasta, false)
+                },
+                SpectralLibrary = library,
+                SearchTaskResults = NewTaskResults(task)
+            };
+
+            InvokePrivate(task, "UpdateSpectralLibrary");
+            library.CloseConnections();
+
+            var written = Directory.GetFiles(outputFolder, "updateSpectralLibrary*.msp").Single();
+            var updated = new SpectralLibrary(new List<string> { written });
+            var sequences = updated.GetAllLibrarySpectra().Select(s => s.Sequence).ToList();
+            updated.CloseConnections();
+
+            Assert.That(sequences.Count, Is.EqualTo(3), "neither match qualifies, so the library is unchanged");
+            Assert.That(sequences, Does.Not.Contain("DECOYPEPTIDEK"));
+            Assert.That(sequences, Does.Not.Contain("BADQVALUEPEPTIDEK"));
+
+            Directory.Delete(outputFolder, recursive: true);
+        }
+
+        #region helpers
+
+        /// <summary>KAPAGGAADAAAK is one of the three spectra in spectralLibraryForTestingLibraryUpdate.msp.</summary>
+        private const string RepeatedSequence = "KAPAGGAADAAAK";
+
+        private static string SmallLibrary => Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "TestData", "SpectralLibrarySearch", "spectralLibraryForTestingLibraryUpdate.msp");
+
+        private static string HelaSnipFasta => Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "TestData", "hela_snip_for_unitTest.fasta");
+
+        private static string MakeOutputFolder(string name)
+        {
+            string folder = Path.Combine(TestContext.CurrentContext.TestDirectory,
+                "SpectralLibraryUpdateTests", name);
+            if (Directory.Exists(folder))
+            {
+                Directory.Delete(folder, true);
+            }
+            Directory.CreateDirectory(folder);
+            return folder;
+        }
+
+        /// <summary>
+        /// A scored, FDR-resolved PSM for the given sequence, built from a synthetic scan of that peptide's
+        /// own fragments so the matched ion list is real rather than empty. Score is set independently of
+        /// the ion count because the update rule compares the two against each other.
+        /// </summary>
+        private static SpectralMatch MakePsm(string sequence, int charge, double score,
+            bool isDecoy = false, double qValue = 0)
+        {
+            var commonParameters = new CommonParameters();
+            var protein = new Protein(sequence, isDecoy ? "DECOY_acc" : "acc", isDecoy: isDecoy);
+            var peptide = new PeptideWithSetModifications(protein, commonParameters.DigestionParams,
+                1, sequence.Length, CleavageSpecificity.Full, "", 0, new Dictionary<int, Modification>(), 0);
+
+            MsDataFile dataFile = new TestDataFile(peptide, "quadratic");
+            var scan = new Ms2ScanWithSpecificMass(dataFile.GetOneBasedScan(2),
+                peptide.MonoisotopicMass.ToMz(charge), charge, null, commonParameters);
+
+            var theoretical = new List<Product>();
+            peptide.Fragment(DissociationType.HCD, FragmentationTerminus.Both, theoretical);
+            var matched = MetaMorpheusEngine.MatchFragmentIons(scan, theoretical, commonParameters);
+
+            SpectralMatch psm = new PeptideSpectralMatch(peptide, 0, score, 1, scan, commonParameters, matched);
+            psm.ResolveAllAmbiguities();
+            psm.SetFdrValues(0, 0, qValue, 0, 0, 0, 0, 0);
+            return psm;
+        }
+
+        /// <summary>MyTaskResults has an internal constructor and TaskLayer does not expose internals to Test.</summary>
+        private static MyTaskResults NewTaskResults(MetaMorpheusTask task) =>
+            (MyTaskResults)Activator.CreateInstance(typeof(MyTaskResults),
+                BindingFlags.Instance | BindingFlags.NonPublic, null, new object[] { task }, null);
+
+        private static void InvokePrivate(PostSearchAnalysisTask task, string methodName)
+        {
+            // The parameterless overload has to be named explicitly: MetaMorpheusTask carries a
+            // protected UpdateSpectralLibrary(List<LibrarySpectrum>, string) that would otherwise tie.
+            var method = typeof(PostSearchAnalysisTask).GetMethod(methodName,
+                BindingFlags.NonPublic | BindingFlags.Instance, null, Type.EmptyTypes, null);
+            Assert.That(method, Is.Not.Null, methodName + " was renamed or removed");
+            try
+            {
+                method.Invoke(task, null);
+            }
+            catch (TargetInvocationException e)
+            {
+                throw e.InnerException ?? e;
+            }
+        }
+
+        private static List<string> CaptureWarnings(Action action)
+        {
+            var warnings = new List<string>();
+            void Handler(object sender, StringEventArgs e) => warnings.Add(e.S);
+
+            MetaMorpheusTask.WarnHandler += Handler;
+            try
+            {
+                action();
+            }
+            finally
+            {
+                MetaMorpheusTask.WarnHandler -= Handler;
+            }
+            return warnings;
+        }
+
+        /// <summary>
+        /// RunTask writes its settings toml to a "Task Settings" folder beside the output folder, so the
+        /// fixture's own directory outlives the tests that created it.
+        /// </summary>
+        [OneTimeTearDown]
+        public static void TearDown()
+        {
+            string root = Path.Combine(TestContext.CurrentContext.TestDirectory, "SpectralLibraryUpdateTests");
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, true);
+            }
+        }
+
+        #endregion
     }
 }


### PR DESCRIPTION
Tests for smith-chem-wisc/MetaMorpheus#2721, targeted at this branch rather than master so they land with the fix. Take them, edit them, or ignore them — I won't be offended.

## Why

codecov/patch is red on #2721 at **57.14%**: 7 patch lines, 4 hit, 2 miss, 1 partial. Every uncovered line is the guard you added to `PostSearchAnalysisTask`:

| Line | | |
|---|---|---|
| `PostSearchAnalysisTask.cs:823` | `if (Parameters.SpectralLibrary is null)` | partial — the true branch is never taken |
| `PostSearchAnalysisTask.cs:825` | `Warn(...)` | miss |
| `PostSearchAnalysisTask.cs:826` | `return;` | miss |

That is a consequence of the fix working: `SearchTask` refuses the combination before searching, so nothing that goes through `SearchTask` can reach the guard. The only caller that can is the one you describe in the PR — "any caller assembling `PostSearchAnalysisParameters` on its own" — so that is what these tests are.

## What they do

`PostSearchAnalysisTask.Parameters` has a public setter and `SearchTask.cs:531` already builds the task by object initializer in production, so a test can construct it the same way and reflect into the private method, which is what `PostSearchAnalysisTaskTests.WriteDigestionCountsByProtein_WritesCorrectFile` already does. No search runs. **The whole fixture is 8 tests in 856 ms**, against ~7 s for the one existing update test (`MatchIonsOfAllCharges.TestLibraryUpdate`), which needs two mzML files and a full `EverythingRunnerEngine` pass.

| Test | Pins |
|---|---|
| `UpdatingASpectralLibraryWithoutOneIsRefusedBeforeSearching` | yours, unchanged |
| `LoadSpectralLibrariesReturnsNullOnlyWhenNoLibraryIsInTheDatabaseList` | the precondition your `SearchTask` guard reads. If this ever returned an empty `SpectralLibrary` instead of `null`, your refusal would silently stop firing |
| `UpdateSpectralLibraryWithoutALibraryWarnsAndLeavesNothingBehind` | **the uncovered guard.** Warns, writes no `.msp`, writes **no `UpdateSpectralLibrary_crash.txt`**, advertises no new database |
| `UpdateSpectralLibraryWithNoSearchResultsCarriesEveryOriginalSpectrumThrough` | every original spectrum survives; the updated library *and* the original FASTA both reach `NewDatabases` |
| `UpdateSpectralLibraryPrefersTheBetterOfTheStoredSpectrumAndTheSearchResult` (2 cases) | the selection rule — stored ion count vs PSM score, both outcomes |
| `UpdateSpectralLibraryAppendsAPeptideTheLibraryHasNotSeen` | growth, which is the point of asking for an update |
| `UpdateSpectralLibraryIgnoresDecoyAndLowConfidenceMatches` | decoys and q > threshold stay out of a library the next search will treat as ground truth |

The last four cover `UpdateSpectralLibrary`'s body, which was previously observable only through that seven-second search.

## The guard test actually fails without the guard

Worth stating, because a test written against code that already works proves very little. I deleted lines 823-826 from your branch and re-ran:

```
Failed UpdateSpectralLibraryWithoutALibraryWarnsAndLeavesNothingBehind [35 ms]
  Assert.That(warnings.Any(w => w.Contains("spectral library", StringComparison.OrdinalIgnoreCase)), Is.True)
```

Without the guard, `Parameters.SpectralLibrary.GetAllLibrarySpectra()` at `:841` throws, the surrounding `catch` calls `EngineCrashed`, and the only warning emitted is `"UpdateSpectralLibrary engine Crashed! Error written to ..."` — which does not name a spectral library in words a user would recognise, and leaves a crash file behind. That is the behaviour your guard replaces, and it is what these assertions discriminate against. Guard restored, all 8 green.

## Notes

- Fixture is `TestData\SpectralLibrarySearch\spectralLibraryForTestingLibraryUpdate.msp` — 3 spectra, 2.6 KB, already tracked and already registered in `Test.csproj:479`, but referenced by no test until now. It looks like it was added for exactly this. **No new fixture files**, so no csproj change.
- Added a `[OneTimeTearDown]` that removes the whole `SpectralLibraryUpdateTests` root. `RunTask` writes its toml to `Directory.GetParent(output_folder)\Task Settings` (`MetaMorpheusTask.cs:627`), which is one level *above* the folder the existing test deletes, so it survives every run today. Same cleanup `CalibrationTests.cs:273` and `BinGenerationTest.cs:80` do.
- `MyTaskResults` has an internal constructor and `TaskLayer` does not expose internals to `Test`, so it is built by reflection. If you would rather add `[assembly: InternalsVisibleTo("Test")]` to `TaskLayer` that helper goes away, but that felt like a bigger decision than this PR should make.
- I deliberately did **not** add the "assert the search did not run" check I asked for in review — that belongs in your test, and how to word it is your call.

I left three review comments on #2721 itself; none of them are addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
