### PR TITLE
Fragment peptides in parallel when building the index (47s -> 23s, one fragmentation pass instead of two)

### DIFF
--- a/MetaMorpheus/EngineLayer/Indexing/FragmentIndexBuilder.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/FragmentIndexBuilder.cs
@@ -1,0 +1,167 @@
+using System;
+using System.Collections.Generic;
+
+namespace EngineLayer.Indexing
+{
+    /// <summary>
+    /// The bins one contiguous block of peptides fragmented into, recorded in emission order.
+    ///
+    /// A block records its own emissions rather than writing into the shared index, which is what lets
+    /// blocks fragment in parallel. Runs are concatenated in block order afterwards, so the sequence the
+    /// builder sees is exactly the sequence a single sequential pass would have produced -- the index does
+    /// not depend on how many blocks there were, or on which finished first.
+    /// </summary>
+    internal sealed class FragmentEmissionRun
+    {
+        private int[] _bins;
+        private int[] _runLengths;
+        private int _emissionCount;
+        private int _peptideCount;
+        private int _emissionsForCurrentPeptide;
+        private bool _peptideOpen;
+
+        internal FragmentEmissionRun(int firstPeptideId, int expectedPeptides = 16)
+        {
+            FirstPeptideId = firstPeptideId;
+            _bins = new int[Math.Max(16, expectedPeptides)];
+            _runLengths = new int[Math.Max(16, expectedPeptides)];
+        }
+
+        /// <summary>Peptide id the first run length belongs to. Ids ascend by one from here.</summary>
+        internal int FirstPeptideId { get; }
+
+        internal int[] Bins => _bins;
+        internal int[] RunLengths => _runLengths;
+        internal int EmissionCount => _emissionCount;
+        internal int PeptideCount => _peptideCount;
+
+        /// <summary>
+        /// Starts the emissions for the next peptide id. Must be called once per peptide in the block, in
+        /// ascending id order, including for peptides that emit nothing -- the run lengths are what map
+        /// emissions back to peptide ids, so a skipped peptide would shift every id after it.
+        /// </summary>
+        internal void BeginPeptide()
+        {
+            if (_peptideOpen)
+            {
+                Append(ref _runLengths, _peptideCount, _emissionsForCurrentPeptide);
+                _peptideCount++;
+            }
+
+            _peptideOpen = true;
+            _emissionsForCurrentPeptide = 0;
+        }
+
+        internal void Add(int bin)
+        {
+            Append(ref _bins, _emissionCount, bin);
+            _emissionCount++;
+            _emissionsForCurrentPeptide++;
+        }
+
+        /// <summary>Closes the final peptide. Call once, after the last BeginPeptide/Add.</summary>
+        internal void Complete()
+        {
+            if (_peptideOpen)
+            {
+                Append(ref _runLengths, _peptideCount, _emissionsForCurrentPeptide);
+                _peptideCount++;
+                _peptideOpen = false;
+            }
+        }
+
+        private static void Append(ref int[] array, int index, int value)
+        {
+            if (index == array.Length)
+            {
+                Array.Resize(ref array, array.Length * 2);
+            }
+            array[index] = value;
+        }
+    }
+
+    /// <summary>
+    /// Turns per-block emission runs into a <see cref="FragmentIndex"/>.
+    ///
+    /// A stable counting sort over the concatenated runs: count how many emissions land in each bin,
+    /// prefix-sum the counts into offsets, then scatter. Stability is what makes peptide ids ascend
+    /// within a bin, which the search relies on -- BinarySearchBinForPrecursorIndex binary-searches a bin
+    /// by peptide mass, and peptides are sorted by mass, so ascending id means ascending mass.
+    /// </summary>
+    internal static class FragmentIndexBuilder
+    {
+        internal static FragmentIndex Build(int binCount, IReadOnlyList<FragmentEmissionRun> runsInEmissionOrder)
+        {
+            // binStart doubles as the counting array and then as the scatter cursor, so a 30M-bin index
+            // needs one 120 MB array here rather than three.
+            int[] binStart;
+
+            try
+            {
+                binStart = new int[binCount + 1];
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new MetaMorpheusException("Max fragment mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
+            }
+
+            // Total in a long: the prefix sum below is int arithmetic and would wrap silently.
+            long totalEntries = 0;
+            foreach (FragmentEmissionRun run in runsInEmissionOrder)
+            {
+                int[] bins = run.Bins;
+                int n = run.EmissionCount;
+                for (int i = 0; i < n; i++)
+                {
+                    binStart[bins[i] + 1]++;
+                }
+                totalEntries += n;
+            }
+
+            if (totalEntries > int.MaxValue)
+            {
+                throw new MetaMorpheusException("Too many fragments to index; try \"Classic Search\" mode, more partitions, or a smaller maximum fragment mass");
+            }
+
+            for (int bin = 1; bin <= binCount; bin++)
+            {
+                binStart[bin] += binStart[bin - 1];
+            }
+
+            int[] peptideIds;
+            try
+            {
+                peptideIds = new int[totalEntries];
+            }
+            catch (OutOfMemoryException)
+            {
+                throw new MetaMorpheusException("Max fragment mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
+            }
+
+            // Scatter, using binStart itself as the per-bin write cursor.
+            foreach (FragmentEmissionRun run in runsInEmissionOrder)
+            {
+                int[] bins = run.Bins;
+                int[] runLengths = run.RunLengths;
+                int peptideId = run.FirstPeptideId;
+                int emission = 0;
+
+                for (int p = 0; p < run.PeptideCount; p++)
+                {
+                    int emissionsForThisPeptide = runLengths[p];
+                    for (int k = 0; k < emissionsForThisPeptide; k++)
+                    {
+                        peptideIds[binStart[bins[emission++]]++] = peptideId;
+                    }
+                    peptideId++;
+                }
+            }
+
+            // Scattering left binStart[bin] holding the start of bin + 1; shift it back.
+            Array.Copy(binStart, 0, binStart, 1, binCount);
+            binStart[0] = 0;
+
+            return new FragmentIndex(binStart, peptideIds);
+        }
+    }
+}

--- a/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
+++ b/MetaMorpheus/EngineLayer/Indexing/IndexingEngine.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Omics;
 using Omics.Fragmentation.Peptide;
@@ -153,120 +154,167 @@ namespace EngineLayer.Indexing
                 NonSpecificEnzymeSearchEngine.GetVariableTerminalMods(CommonParameters.DigestionParams.FragmentationTerminus, VariableModifications) :
                 null;
 
-            // Create the fragment index in compressed sparse row form: count how many peptide ids land in each
-            // bin, prefix-sum those counts into offsets, then fill. Counting first costs a second pass over
-            // the fragments but removes the several million List<int> objects the previous representation
-            // allocated and grew, which dominated this loop.
+            // Create the fragment index in compressed sparse row form. Peptide ids are split into
+            // contiguous blocks, one per thread; each block fragments its own peptides into its own
+            // emission run, and the runs are concatenated in block order and counting-sorted into the
+            // two flat arrays. Concatenating in block order reproduces the sequence a single sequential
+            // pass produced, so the index does not depend on the thread count and peptide ids still
+            // ascend within every bin.
+            //
+            // Fragmenting once and recording where each fragment landed replaces counting in one pass
+            // and filling in a second: fragmentation is the expensive part of this loop, and the
+            // count-then-fill shape paid for it twice. Digestion above was already parallel; this stage
+            // was not, so a whole phase of indexing ran on one core.
             int binCount = (int)Math.Ceiling(MaxFragmentSize) * FragmentBinsPerDalton + 1;
-            int[] binStart;
 
-            try
-            {
-                binStart = new int[binCount + 1];
-            }
-            catch (OutOfMemoryException)
-            {
-                throw new MetaMorpheusException("Max fragment mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
-            }
+            List<PeptideBlock> blocks = PartitionPeptidesIntoBlocks(peptides.Count);
+            var fragmentEmissions = new FragmentEmissionRun[blocks.Count];
+            var interiorTerminalModEmissions = addInteriorTerminalModsToPrecursorIndex ? new List<(int Bin, int PeptideId)>[blocks.Count] : null;
+            var fragmentationProgress = new FragmentationProgress();
 
-            // pass one: count
             progress = 0;
             oldPercentProgress = 0;
-            List<Product> fragments = new List<Product>();
 
-            for (int peptideId = 0; peptideId < peptides.Count; peptideId++)
+            Parallel.For(0, blocks.Count, new ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, CommonParameters.MaxThreadsToUsePerFile) }, blockIndex =>
             {
-                peptides[peptideId].Fragment(CommonParameters.DissociationType, CommonParameters.DigestionParams.FragmentationTerminus, fragments, CommonParameters.FragmentationParameters);
+                FragmentPeptideBlock(blocks[blockIndex], blockIndex, peptides, addInteriorTerminalModsToPrecursorIndex,
+                    terminalModifications, fragmentEmissions, interiorTerminalModEmissions, fragmentationProgress);
+            });
 
-                foreach (var theoreticalFragment in fragments)
+            FragmentIndex fragmentIndex = FragmentIndexBuilder.Build(binCount, fragmentEmissions);
+
+            // Replayed in block order, and within a block in ascending peptide id, which is the order the
+            // sequential loop appended them in. The precursor index is still a List<int>[] here, so the
+            // append order is the bin contents.
+            if (addInteriorTerminalModsToPrecursorIndex)
+            {
+                foreach (var blockEmissions in interiorTerminalModEmissions)
                 {
-                    if (TryGetFragmentBin(theoreticalFragment, out int fragmentBin))
+                    foreach ((int precursorBin, int peptideId) in blockEmissions)
                     {
-                        // counts land one slot right so the prefix sum below can run in place
-                        binStart[fragmentBin + 1]++;
+                        if (precursorIndex[precursorBin] == null)
+                        {
+                            precursorIndex[precursorBin] = new List<int> { peptideId };
+                        }
+                        else
+                        {
+                            precursorIndex[precursorBin].Add(peptideId);
+                        }
                     }
                 }
-
-                progress++;
-                var percentProgress = (int)((progress / peptides.Count) * 100);
-
-                if (percentProgress > oldPercentProgress)
-                {
-                    oldPercentProgress = percentProgress;
-                    ReportProgress(new ProgressEventArgs(percentProgress, "Fragmenting peptides...", NestedIds));
-                }
             }
 
-            // Total first, in a long: the prefix sum below is int arithmetic and would wrap silently.
-            long totalEntries = 0;
-            for (int bin = 1; bin <= binCount; bin++)
+
+            return new IndexingResults(peptides, fragmentIndex, precursorIndex, this);
+        }
+
+        /// <summary>
+        /// Counts fragmented peptides across the parallel blocks. Each whole percent is announced by
+        /// exactly one thread -- whichever wins the compare-exchange that advances the counter -- so the
+        /// progress bar neither stalls nor reports the same percent several times.
+        /// </summary>
+        private sealed class FragmentationProgress
+        {
+            private long _peptidesFragmented;
+            private int _lastPercentReported;
+
+            internal bool AdvanceOnePeptide(int totalPeptides, out int percentProgress)
             {
-                totalEntries += binStart[bin];
+                long done = Interlocked.Increment(ref _peptidesFragmented);
+                percentProgress = (int)(done * 100 / totalPeptides);
+
+                int last = Volatile.Read(ref _lastPercentReported);
+                return percentProgress > last && Interlocked.CompareExchange(ref _lastPercentReported, percentProgress, last) == last;
+            }
+        }
+
+        private readonly struct PeptideBlock
+        {
+            public PeptideBlock(int start, int end)
+            {
+                Start = start;
+                End = end;
             }
 
-            if (totalEntries > int.MaxValue)
+            /// <summary>First peptide id in the block.</summary>
+            public int Start { get; }
+
+            /// <summary>One past the last peptide id in the block.</summary>
+            public int End { get; }
+        }
+
+        /// <summary>
+        /// Splits the peptide ids into contiguous blocks, one per thread. Emissions are concatenated in
+        /// block order, so the index that comes out does not depend on how many blocks there are.
+        /// </summary>
+        private List<PeptideBlock> PartitionPeptidesIntoBlocks(int peptideCount)
+        {
+            var blocks = new List<PeptideBlock>();
+            if (peptideCount == 0)
             {
-                throw new MetaMorpheusException("Too many fragments to index; try \"Classic Search\" mode, more partitions, or a smaller maximum fragment mass");
+                return blocks;
             }
 
-            for (int bin = 1; bin <= binCount; bin++)
+            int blockCount = Math.Max(1, Math.Min(CommonParameters.MaxThreadsToUsePerFile, peptideCount));
+            int blockSize = (peptideCount + blockCount - 1) / blockCount;
+
+            for (int start = 0; start < peptideCount; start += blockSize)
             {
-                binStart[bin] += binStart[bin - 1];
+                blocks.Add(new PeptideBlock(start, Math.Min(start + blockSize, peptideCount)));
             }
 
-            int[] peptideIds;
-            try
-            {
-                peptideIds = new int[totalEntries];
-            }
-            catch (OutOfMemoryException)
-            {
-                throw new MetaMorpheusException("Max fragment mass too large for indexing engine; try \"Classic Search\" mode, or make the maximum fragment mass smaller");
-            }
+            return blocks;
+        }
 
-            // Pass two: fill. Peptides are visited in ascending id, so each bin's slice comes out ascending,
-            // which is what the search's within-bin binary search over peptide mass relies on. binStart is
-            // consumed as the write cursor and repaired afterwards rather than copied - a copy would be
-            // another array the size of the bin space, which is the memory this whole change is saving.
-            progress = 0;
-            oldPercentProgress = 0;
+        /// <summary>
+        /// Fragments one contiguous block of peptides, recording the fragment bins each peptide lands in
+        /// and, when the search needs them, the interior terminal mod precursor bins -- which come out of
+        /// the same fragmentation, so peptides are still fragmented exactly once.
+        /// </summary>
+        private void FragmentPeptideBlock(PeptideBlock block, int blockIndex, List<PeptideWithSetModifications> peptides,
+            bool addInteriorTerminalModsToPrecursorIndex, List<Modification> terminalModifications,
+            FragmentEmissionRun[] fragmentEmissions, List<(int Bin, int PeptideId)>[] interiorTerminalModEmissions,
+            FragmentationProgress fragmentationProgress)
+        {
+            int blockLength = block.End - block.Start;
+            var fragmentRun = new FragmentEmissionRun(block.Start, blockLength);
+            var interiorEmissions = addInteriorTerminalModsToPrecursorIndex ? new List<(int Bin, int PeptideId)>() : null;
 
-            for (int peptideId = 0; peptideId < peptides.Count; peptideId++)
+            List<Product> fragments = new List<Product>();
+
+            for (int peptideId = block.Start; peptideId < block.End; peptideId++)
             {
+                fragmentRun.BeginPeptide();
+
                 peptides[peptideId].Fragment(CommonParameters.DissociationType, CommonParameters.DigestionParams.FragmentationTerminus, fragments, CommonParameters.FragmentationParameters);
 
                 foreach (var theoreticalFragment in fragments)
                 {
                     if (TryGetFragmentBin(theoreticalFragment, out int fragmentBin))
                     {
-                        peptideIds[binStart[fragmentBin]++] = peptideId;
+                        fragmentRun.Add(fragmentBin);
                     }
                 }
 
                 //Add terminal mods if needed (do it here rather than earlier so that we don't have to fragment twice)
                 if (addInteriorTerminalModsToPrecursorIndex)
                 {
-                    AddInteriorTerminalModsToPrecursorIndex(precursorIndex, fragments, peptides[peptideId], peptideId, terminalModifications);
+                    CollectInteriorTerminalModPrecursorBins(interiorEmissions, fragments, peptides[peptideId], peptideId, terminalModifications);
                 }
 
-                progress++;
-                var percentProgress = (int)((progress / peptides.Count) * 100);
-
-                if (percentProgress > oldPercentProgress)
+                if (fragmentationProgress.AdvanceOnePeptide(peptides.Count, out int percentProgress))
                 {
-                    oldPercentProgress = percentProgress;
                     ReportProgress(new ProgressEventArgs(percentProgress, "Fragmenting peptides...", NestedIds));
                 }
             }
 
-            // Filling left binStart[bin] holding the start of bin + 1; shift it back.
-            for (int bin = binCount; bin > 0; bin--)
-            {
-                binStart[bin] = binStart[bin - 1];
-            }
-            binStart[0] = 0;
+            fragmentRun.Complete();
 
-            return new IndexingResults(peptides, new FragmentIndex(binStart, peptideIds), precursorIndex, this);
+            fragmentEmissions[blockIndex] = fragmentRun;
+            if (interiorTerminalModEmissions != null)
+            {
+                interiorTerminalModEmissions[blockIndex] = interiorEmissions;
+            }
         }
 
         /// <summary>
@@ -374,7 +422,13 @@ namespace EngineLayer.Indexing
 
         //add possible protein/peptide terminal modifications that aren't on the terminal amino acids
         //The purpose is for terminal mods that are contained WITHIN the Single peptide
-        private void AddInteriorTerminalModsToPrecursorIndex(List<int>[] precursorIndex, List<Product> fragmentMasses, PeptideWithSetModifications peptide, int peptideId, List<Modification> variableModifications)
+        /// <summary>
+        /// Records the interior terminal mod precursor bins for one peptide instead of writing them into
+        /// the precursor index directly. The blocks fragment in parallel and the precursor index is a
+        /// shared List&lt;int&gt;[], so the writes are replayed in block order afterwards -- which is the
+        /// order the sequential loop appended them in, and the bin contents are that order.
+        /// </summary>
+        private void CollectInteriorTerminalModPrecursorBins(List<(int Bin, int PeptideId)> emissions, List<Product> fragmentMasses, PeptideWithSetModifications peptide, int peptideId, List<Modification> variableModifications)
         {
             //Get database annotated mods
             Dictionary<int, List<Modification>> databaseAnnotatedMods = NonSpecificEnzymeSearchEngine.GetTerminalModPositions(peptide, CommonParameters.DigestionParams, variableModifications);
@@ -401,15 +455,7 @@ namespace EngineLayer.Indexing
                     if (modifiedMass <= MaxFragmentSize) //if the precursor is larger than the index allows, then don't add it
                     {
                         int precursorBin = (int)Math.Round(modifiedMass * FragmentBinsPerDalton);
-
-                        if (precursorIndex[precursorBin] == null)
-                        {
-                            precursorIndex[precursorBin] = new List<int> { peptideId };
-                        }
-                        else
-                        {
-                            precursorIndex[precursorBin].Add(peptideId);
-                        }
+                        emissions.Add((precursorBin, peptideId));
                     }
                 }
             }

--- a/MetaMorpheus/Test/IndexEngineTest.cs
+++ b/MetaMorpheus/Test/IndexEngineTest.cs
@@ -18,6 +18,98 @@ namespace Test
     [TestFixture]
     public static class IndexEngineTest
     {
+        /// <summary>
+        /// The fragment index is built in parallel over contiguous blocks of peptide ids, and the number
+        /// of blocks follows MaxThreadsToUsePerFile. The index that comes out has to be identical
+        /// regardless -- peptide ids must stay ascending within a bin, because the search binary searches
+        /// a bin by peptide mass and that only holds while ids ascend.
+        /// </summary>
+        [Test]
+        public static void TestIndexIsIdenticalRegardlessOfThreadCount()
+        {
+            var proteinList = new List<Protein>
+            {
+                new Protein("MNNNKQQQMNNNKQQQPEPTIDEKMSSSRTTTKAAAWWWKGGGYYYK", "prot1"),
+                new Protein("MKVLINGYGTIGKRVADAVSQQDDMKVIGVSKTRPDFEARMALQKGYDLYVAIPK", "prot2"),
+                new Protein("MSDKIIHLTDDSFDTDVLKADGAILVDFWAEWCGPCKMIAPILDEIADEYQGKLTVAK", "prot3"),
+            };
+
+            var fixedModifications = new List<Modification>();
+            var variableModifications = new List<Modification>();
+
+            FragmentIndex referenceFragmentIndex = null;
+            List<PeptideWithSetModifications> referencePeptideIndex = null;
+
+            foreach (int threadCount in new[] { 1, 2, 3, 8 })
+            {
+                var commonParameters = new CommonParameters(maxThreadsToUsePerFile: threadCount);
+
+                var engine = new IndexingEngine(proteinList, variableModifications, fixedModifications, null, null, null, 0,
+                    DecoyType.Reverse, commonParameters, null, 30000, false, new List<FileInfo>(),
+                    TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+                var results = (IndexingResults)engine.Run();
+
+                if (referenceFragmentIndex == null)
+                {
+                    referenceFragmentIndex = results.FragmentIndex;
+                    referencePeptideIndex = results.PeptideIndex;
+                    Assert.That(referenceFragmentIndex.EntryCount, Is.GreaterThan(0), "index came out empty; the test proves nothing");
+                    continue;
+                }
+
+                Assert.That(results.PeptideIndex.Count, Is.EqualTo(referencePeptideIndex.Count), $"peptide count differs at {threadCount} threads");
+                Assert.That(results.FragmentIndex.Length, Is.EqualTo(referenceFragmentIndex.Length), $"bin count differs at {threadCount} threads");
+                Assert.That(results.FragmentIndex.EntryCount, Is.EqualTo(referenceFragmentIndex.EntryCount), $"entry count differs at {threadCount} threads");
+
+                for (int bin = 0; bin < referenceFragmentIndex.Length; bin++)
+                {
+                    if (referenceFragmentIndex[bin].Length == 0 && results.FragmentIndex[bin].Length == 0)
+                    {
+                        continue;
+                    }
+
+                    Assert.That(results.FragmentIndex[bin].ToArray(), Is.EqualTo(referenceFragmentIndex[bin].ToArray()),
+                        $"bin {bin} differs at {threadCount} threads");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Peptide ids ascend within every bin. BinarySearchBinForPrecursorIndex depends on it.
+        /// </summary>
+        [Test]
+        public static void TestFragmentIndexBinsAreSortedByPeptideId()
+        {
+            var proteinList = new List<Protein>
+            {
+                new Protein("MNNNKQQQMNNNKQQQPEPTIDEKMSSSRTTTKAAAWWWKGGGYYYK", "prot1"),
+                new Protein("MSDKIIHLTDDSFDTDVLKADGAILVDFWAEWCGPCKMIAPILDEIADEYQGKLTVAK", "prot2"),
+            };
+
+            var engine = new IndexingEngine(proteinList, new List<Modification>(), new List<Modification>(), null, null, null, 0,
+                DecoyType.Reverse, new CommonParameters(), null, 30000, false, new List<FileInfo>(),
+                TargetContaminantAmbiguity.RemoveContaminant, new List<string>());
+
+            var results = (IndexingResults)engine.Run();
+
+            int binsChecked = 0;
+            for (int bin = 0; bin < results.FragmentIndex.Length; bin++)
+            {
+                ReadOnlySpan<int> ids = results.FragmentIndex[bin];
+                for (int i = 1; i < ids.Length; i++)
+                {
+                    Assert.That(ids[i], Is.GreaterThan(ids[i - 1]), $"bin {bin} is not ascending");
+                }
+                if (ids.Length > 1)
+                {
+                    binsChecked++;
+                }
+            }
+
+            Assert.That(binsChecked, Is.GreaterThan(0), "no multi-entry bins; the test proves nothing");
+        }
+
         [Test]
         public static void TestIndexEngine()
         {


### PR DESCRIPTION
🤖 Against your branch, not master — this is a build-strategy change on top of your `FragmentIndex`, and it adds nothing to the layout.

Context: I opened smith-chem-wisc/MetaMorpheus#2758 without noticing #2742 had been open since the 18th, and the two turned out to be the same CSR index written twice. Rather than ask you to drop yours, I'm retiring mine and bringing over the one part of it that isn't duplicated. `MassBinIndex` is gone; `FragmentIndex.cs` is untouched by this PR.

## What

`GenerateIndex` counted into `binStart` in one pass and filled in a second. Both passes are serial, and both call `peptides[peptideId].Fragment(...)` — so the whole database is fragmented twice, on one core, immediately after a digestion step that is already parallel.

This replaces that with: split the peptide ids into contiguous blocks, one per thread; each block fragments its own peptides once and records which bins they landed in; concatenate the runs in block order and counting-sort them into `binStart`/`peptideIds`.

Concatenating in block order is what makes it deterministic — the builder sees exactly the sequence a single sequential pass would have produced, so the index does not depend on the thread count and peptide ids still ascend within every bin. `BinarySearchBinForPrecursorIndex` needs that: peptides are sorted by mass, so ascending id within a bin means ascending mass.

`TryGetFragmentBin` stays the single source of the bin arithmetic, so the low-resolution rounding can't drift between phases — the reason you gave for extracting it holds here too.

The precursor index is left alone; it's still `List<int>[]`. Interior terminal mod entries come out of the same fragmentation, so they're recorded per block and replayed into it in block order afterwards, which is the order the sequential loop appended them in.

## Measured

Full reviewed human proteome (78,120 entries), tryptic, no variable mods, 63 threads, Release, same machine, two reps each:

| | total index build | allocated |
|---|---|---|
| `526eef95` (this branch) | 47.1 s / 47.9 s | 51.2 GB |
| with this change | **23.4 s / 25.1 s** | **34.1 GB** |

Both produce 6,907,559 peptides and 289,901,771 entries. That is the whole of `IndexingEngine.Run()`, digestion included, so the fragmentation phase itself moved more than the 2x the total shows. The allocation drop is the second fragmentation going away.

## Verified identical, not assumed

Hashing the full bin contents of the built index — every occupied bin, in order, plus the precursor index where there is one — on your branch and on this one:

```
tryptic  (ordinary, no precursor index)              FA7C57F6...D63FD72E   both
nonspec  (singleN, precursor index + interior mods)  38FF290C...D249BD99   both
```

at 1 and 4 threads, four combinations, all matching. The non-specific case is the one that matters most, since that is where the write ordering changed.

Two tests pin the invariance directly: `TestIndexIsIdenticalRegardlessOfThreadCount` builds the same database at 1, 2, 3 and 8 threads and compares every bin, and `TestFragmentIndexBinsAreSortedByPeptideId` asserts ids ascend.

Full suite on this branch: **1892 passed, 1 skipped, 0 failed**.

## Note

Take it, take part of it, or close it — it's your PR and your call. If you'd rather land #2742 as-is and do this afterwards, that's fine too; I'd just rather it existed as a reviewable diff against your code than as an argument on the thread.
